### PR TITLE
Add support to CachedEntity finalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ appsettings.*.json
 *.csproj.user
 published
 nuget-packages
+.idea

--- a/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/InteropFuncCallbackTest.razor
+++ b/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/InteropFuncCallbackTest.razor
@@ -21,6 +21,7 @@
         _invokableReference = DotNetObjectReference.Create(
             _messageUpdateInvokeHelper
         );
+
         _funcCallbackClass = EventHorizonBlazorInterop.New(
             new object[]
             {

--- a/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Scenarios/InteropFinalizationTest.razor
+++ b/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Scenarios/InteropFinalizationTest.razor
@@ -1,0 +1,87 @@
+﻿<div>
+    <h3>Finalization Validation</h3>
+    <div class="--lighter"></div>
+    <div>
+        Status:
+        @if (TestStatus == "Passed")
+        {
+            <span class="green-badge">@TestStatus</span>
+        }
+        else if (TestStatus == "Failed")
+        {
+            <span class="red-badge">@TestStatus</span>
+        }
+        else
+        {
+            <span>@TestStatus</span>
+        }
+    </div>
+    <button class="run-btn" @onclick="HandleRunTest">Run</button>
+</div>
+
+
+@code {
+    public string TestStatus = "Pending";
+
+    private int result;
+    private int expected;
+
+    private async Task HandleRunTest()
+    {
+        result = 0;
+
+        await RunTest();
+        ValidateTest();
+    }
+
+    public async Task RunTest()
+    {
+        var list = CreateEntities();
+
+        GC.Collect();
+
+        // GC won't collect until we release the thread, so we offload
+        // the rest of it to be completed async.
+        await Task.Delay(10);
+
+        foreach (var guid in list)
+        {
+            var value = EventHorizonBlazorInterop.Get<string>(guid, "X");
+            if (value is not null)
+                result++;
+        }
+    }
+
+    static List<string> CreateEntities()
+    {
+        var list = new List<string>();
+
+        for (var i = 0; i < 100; i++)
+        {
+            var entity = EventHorizonBlazorInterop.FuncClass(
+                e => new Vector3CachedEntity(e),
+                new object[]
+                {
+                    new[] { "funcClass", "func" },
+                }
+                );
+
+            list.Add(entity.___guid);
+        }
+
+        return list;
+    }
+
+    public void ValidateTest()
+    {
+        if (result == expected)
+        {
+            TestStatus = "Passed";
+        }
+        else
+        {
+            TestStatus = "Failed";
+        }
+    }
+
+}

--- a/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Scenarios/InteropFinalizationTest.razor
+++ b/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Scenarios/InteropFinalizationTest.razor
@@ -24,7 +24,6 @@
     public string TestStatus = "Pending";
 
     private int result;
-    private int expected;
 
     private async Task HandleRunTest()
     {
@@ -74,7 +73,7 @@
 
     public void ValidateTest()
     {
-        if (result == expected)
+        if (result == 0)
         {
             TestStatus = "Passed";
         }

--- a/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Scenarios/InteropScenariosPage.razor
+++ b/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Scenarios/InteropScenariosPage.razor
@@ -4,4 +4,5 @@
 
 <div class="testing-content">
     <InteropNewArgumentAsNullTest />
+    <InteropFinalizationTest/>
 </div>

--- a/EventHorizon.Blazor.Interop/CachedEntity.cs
+++ b/EventHorizon.Blazor.Interop/CachedEntity.cs
@@ -9,6 +9,6 @@ namespace EventHorizon.Blazor.Interop
     public class CachedEntity : ICachedEntity
     {
         /// <inheritdoc />
-        public string ___guid { get; set; }
+        public CachedEntityRef ___guid { get; set; }
     }
 }

--- a/EventHorizon.Blazor.Interop/CachedEntityConverter.cs
+++ b/EventHorizon.Blazor.Interop/CachedEntityConverter.cs
@@ -38,7 +38,7 @@ namespace EventHorizon.Blazor.Interop
                     switch (propertyName)
                     {
                         case "___guid":
-                            entity.___guid = reader.GetString();
+                            entity.___guid = new CachedEntityRef(reader.GetString());
                             break;
                     }
                 }

--- a/EventHorizon.Blazor.Interop/CachedEntityRef.cs
+++ b/EventHorizon.Blazor.Interop/CachedEntityRef.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EventHorizon.Blazor.Interop
+{
+    [JsonConverter(typeof(CachedEntityRefConverter))]
+    public sealed class CachedEntityRef : IEquatable<CachedEntityRef>
+    {
+        readonly string _guid;
+
+        internal CachedEntityRef(string guid)
+        {
+            _guid = guid;
+        }
+
+        ~CachedEntityRef()
+        {
+            EventHorizonBlazorInterop.RemoveEntity(_guid);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return _guid;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return (_guid != null ? _guid.GetHashCode() : 0);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(CachedEntityRef other)
+        {
+            return _guid == other?._guid;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj.GetType() == GetType() && Equals((CachedEntityRef) obj);
+        }
+
+        /// <summary>
+        /// Converts an instance of this object to string.
+        /// </summary>
+        /// <param name="obj">A cached entity reference.</param>
+        /// <returns>The internal UUID of the cached entity.</returns>
+        public static implicit operator string(CachedEntityRef obj) => obj.ToString();
+    }
+
+
+    /// <summary>
+    /// This helps with the payload of passing a CacheEntity between the C# and client.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class CachedEntityRefConverter : JsonConverter<CachedEntityRef>
+    {
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert) =>
+            typeof(CachedEntityRef).IsAssignableFrom(typeToConvert);
+
+        /// <inheritdoc />
+        public override CachedEntityRef Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.Read() ? new CachedEntityRef(reader.GetString()) : null;
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, CachedEntityRef value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/EventHorizon.Blazor.Interop/CachedEntityRef.cs
+++ b/EventHorizon.Blazor.Interop/CachedEntityRef.cs
@@ -4,6 +4,10 @@ using System.Text.Json.Serialization;
 
 namespace EventHorizon.Blazor.Interop
 {
+    /// <summary>
+    /// Represents a root reference to JS object. The JS object will live as long as this reference exists,
+    /// and once it is collected, the JS object will also be released for collection by the JS runtime.
+    /// </summary>
     [JsonConverter(typeof(CachedEntityRefConverter))]
     public sealed class CachedEntityRef : IEquatable<CachedEntityRef>
     {
@@ -14,6 +18,7 @@ namespace EventHorizon.Blazor.Interop
             _guid = guid;
         }
 
+        /// <inheritdoc />
         ~CachedEntityRef()
         {
             EventHorizonBlazorInterop.RemoveEntity(_guid);

--- a/EventHorizon.Blazor.Interop/EventHorizonBlazorInterop.cs
+++ b/EventHorizon.Blazor.Interop/EventHorizonBlazorInterop.cs
@@ -118,7 +118,7 @@
                 "blazorInterop.funcClass",
                 args
             );
-            return classBuilder(new CachedEntity { ___guid = cacheKey });
+            return classBuilder(new CachedEntity { ___guid = new CachedEntityRef(cacheKey) });
         }
 
         /// <summary>
@@ -192,7 +192,7 @@
             var index = 0;
             foreach (var result in results)
             {
-                array[index] = classBuilder(new CachedEntity { ___guid = result });
+                array[index] = classBuilder(new CachedEntity { ___guid = new CachedEntityRef(result) });
                 index++;
             }
 
@@ -287,7 +287,7 @@
                 )
             );
 
-            return classBuilder(new CachedEntity { ___guid = result });
+            return classBuilder(new CachedEntity { ___guid = new CachedEntityRef(result) });
         }
 
         /// <summary>
@@ -331,7 +331,7 @@
             var index = 0;
             foreach (var result in results)
             {
-                array[index] = classBuilder(new CachedEntity { ___guid = result });
+                array[index] = classBuilder(new CachedEntity { ___guid = new CachedEntityRef(result) });
                 index++;
             }
 
@@ -409,10 +409,11 @@
             params object[] args
         )
         {
-            return RUNTIME.Invoke<CachedEntity>(
+            var cacheRef = new CachedEntityRef(RUNTIME.Invoke<string>(
                 "blazorInterop.new",
                 args
-            );
+            ));
+            return new CachedEntity { ___guid = cacheRef };
         }
 
         /// <summary>
@@ -530,16 +531,20 @@
         /// <param name="identifier">The <see cref="ICachedEntity.___guid"/> on the client.</param>
         /// <param name="prop">The property on the root the value should be from.</param>
         /// <returns>The cache identifier of the prop value.</returns>
-        public static ICachedEntity cacheEntity(
+        public static ICachedEntity CacheEntity(
             string identifier,
             string prop
         )
         {
-            return RUNTIME.Invoke<CachedEntity>(
-                "blazorInterop.cacheEntity",
-                identifier,
-                prop
+            var cacheRef = new CachedEntityRef(
+                RUNTIME.Invoke<string>(
+                    "blazorInterop.cacheEntity",
+                    identifier,
+                    prop
+                )
             );
+
+            return new CachedEntity { ___guid = cacheRef };
         }
 
 
@@ -614,7 +619,7 @@
                 "blazorInterop.taskClass",
                 args
             );
-            return classBuilder(new CachedEntity { ___guid = cacheKey });
+            return classBuilder(new CachedEntity { ___guid = new CachedEntityRef(cacheKey) });
         }
 
         /// <summary>
@@ -692,11 +697,22 @@
             var index = 0;
             foreach (var result in results)
             {
-                array[index] = classBuilder(new CachedEntity { ___guid = result });
+                array[index] = classBuilder(new CachedEntity { ___guid = new CachedEntityRef(result) });
                 index++;
             }
 
             return array;
+        }
+
+        /// <summary>
+        /// Removes an entity from the cache, allowing the JS runtime to garbage collect it.
+        /// This method is called automatically by any objects derived from <see cref="CachedEntity"/>
+        /// upon finalization.
+        /// </summary>
+        /// <param name="identifier">Identifier is a <see cref="ICachedEntity.___guid"/></param>
+        public static void RemoveEntity(string identifier)
+        {
+            RUNTIME.InvokeVoid("blazorInterop.removeEntity", identifier);
         }
     }
 

--- a/EventHorizon.Blazor.Interop/ICachedEntity.cs
+++ b/EventHorizon.Blazor.Interop/ICachedEntity.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// The Client identifier for this specific entity.
         /// </summary>
-        string ___guid { get; set; }
+        CachedEntityRef ___guid { get; set; }
     }
 }

--- a/EventHorizon.Blazor.Interop/wwwroot/interop-bridge.js
+++ b/EventHorizon.Blazor.Interop/wwwroot/interop-bridge.js
@@ -370,9 +370,7 @@
                 var newObject = new createNew(...args);
                 newObject[cacheKey] = guid();
                 argumentCache.set(newObject[cacheKey], newObject);
-                return {
-                    [cacheKey]: newObject[cacheKey]
-                };
+                return newObject[cacheKey];
             } catch (ex) {
                 console.log("error", ex);
             }
@@ -706,9 +704,10 @@
             var newObject = cachedEntity[prop];
             newObject[cacheKey] = guid();
             argumentCache.set(newObject[cacheKey], newObject);
-            return {
-                [cacheKey]: newObject[cacheKey]
-            };
+            return newObject[cacheKey];
+        },
+        removeEntity: (identifier) => {
+            argumentCache.delete(identifier);
         },
     };
 })();


### PR DESCRIPTION
This PR solves #17 -- I have yet to test on something more complex, but my guess is that this is a good enough start.

This is a major change to the API, although it should be fairly simple to migrate. Although the CachedEntity is not binary compatible due to __guid type being changed from string to CachedEntityRef, the usage has not changed the slightest.

I have not looked into the generator as I don't use it in my project, but my guess is that once the reference is updated there, it should mostly just work.

The rationale for using CachedEntityRef is that users might have been passing __guid up and down and the APIs itself tend to create bare CachedEntity objects as intermediates to hold the __guid. By replacing string with CachedEntityRef, it's possible to have multiple objects pointing to the same underlying JS cached entity and not having the cache entry removed prematurely -- as long as there's a root to the CachedEntityRef somewhere, the JS counterpart will remain in the argument cache.

I wasn't sure where to add new tests to, so I added a test to the scenario tab. All of the other tests seem to be working. I had to make a few changes in the way objects are returned by interop functions such as `new` and `cacheEntity` as the returned object was not being correctly constructed once the ctor changed.