### PR TITLE
fix: Number Format Exception when Converting decimal from JavaScript 🐛

### DIFF
--- a/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Validation/InteropDecimalNumberClutureInfoTest.razor
+++ b/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Validation/InteropDecimalNumberClutureInfoTest.razor
@@ -1,0 +1,78 @@
+﻿@using System.Globalization
+<div>
+    <h3>Literal Decimal Number Cluture Info Validation</h3>
+    <div class="--lighter">Interop Get</div>
+    <div>
+        Status:
+        @if (TestStatus == "Passed")
+        {
+            <span class="green-badge">@TestStatus</span>
+        }
+        else if (TestStatus == "Failed")
+        {
+            <span class="red-badge">@TestStatus</span>
+        }
+        else
+        {
+            <span>@TestStatus</span>
+        }
+    </div>
+    <button class="run-btn" @onclick="HandleRunTest">Run</button>
+</div>
+
+<script suppress-error="BL9992">
+    (function () {
+        window["InteropDecimalNumberClutureInfoTest"] = {
+            value: 0.0000000000000001334646852585,
+        };
+    })();
+</script>
+
+@code {
+    public string TestStatus = "Pending";
+
+    private string testId => "InteropDecimalNumberClutureInfoTest";
+    private decimal result;
+    private decimal expected = 0.0000000000000001334646852585m;
+
+    private void HandleRunTest()
+    {
+        var clutureInfo = CultureInfo.CurrentCulture;
+        try
+        {
+            // Using de-DE because the decimal place is ',' for decimal/numbers.
+            CultureInfo.CurrentCulture = new CultureInfo(
+                "de-DE"
+            );
+
+            RunTest();
+            ValidateTest();
+        }
+        catch { }
+        finally
+        {
+            // Reset back to ClutureInfo before test changed it.
+            CultureInfo.CurrentCulture = clutureInfo;
+        }
+    }
+
+    public void RunTest()
+    {
+        result = EventHorizonBlazorInterop.Get<decimal>(
+            testId,
+            "value"
+        );
+    }
+
+    public void ValidateTest()
+    {
+        if (result == expected)
+        {
+            TestStatus = "Passed";
+        }
+        else
+        {
+            TestStatus = "Failed";
+        }
+    }
+}

--- a/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Validation/InteropValidationsPage.razor
+++ b/EventHorizon.Blazor.Interop.Sample/Pages/Testing/InteropTesting/Validation/InteropValidationsPage.razor
@@ -3,6 +3,7 @@
 <h1>Interop Validations</h1>
 
 <div class="testing-content">
+    <InteropDecimalNumberClutureInfoTest />
     <InteropDecimalNumberTest />
     <InteropFloatNumberTest />
     <InteropIntNumberTest />

--- a/EventHorizon.Blazor.Interop/EventHorizonBlazorInterop.cs
+++ b/EventHorizon.Blazor.Interop/EventHorizonBlazorInterop.cs
@@ -1,6 +1,7 @@
 ﻿namespace EventHorizon.Blazor.Interop
 {
     using System;
+    using System.Globalization;
     using System.Threading.Tasks;
     using Microsoft.JSInterop;
     using Microsoft.JSInterop.WebAssembly;
@@ -209,9 +210,9 @@
         /// <example>
         /// <code>
         /// <![CDATA[
-        /// EventHorizonBlazorInterop.Get<Vector3>(
-        ///     entity => new Vector3(entity),
-        ///     "document.createElement"
+        /// EventHorizonBlazorInterop.Get<decimal>(
+        ///     "document",
+        ///     "nodeType"
         /// );
         /// ]]>
         /// </code>
@@ -240,7 +241,8 @@
             }
             return (T)Convert.ChangeType(
                 result,
-                Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T)
+                Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T),
+                CultureInfo.InvariantCulture
             );
         }
 


### PR DESCRIPTION
Convert.ChangeType would throw a Number Format Exception when the current Culture was not that of a '.' decimal place.
The fix was to update the Convert.ChangeType to use an InvariantCluture when changing the type of a decimal/float number.

fixes #32